### PR TITLE
ci: little fix to teacher's workflow 

### DIFF
--- a/.github/workflows/oop-ci.yml
+++ b/.github/workflows/oop-ci.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    if: contains(github.repository, 'sample-javafx-project') && !github.event.repository.fork
+    if: contains(github.repository, 'wild-enc') && !github.event.repository.fork
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
the original script checked the name of the repository with the wrong name